### PR TITLE
Fix/atlona6x2

### DIFF
--- a/AT-OME-PS62/device.go
+++ b/AT-OME-PS62/device.go
@@ -60,18 +60,24 @@ type audioConfig struct {
 		ZoneOut1 struct {
 			AudioSource string `json:"audioSource"`
 			AudioVol    int    `json:"audioVol"`
-
+			VideoOut    struct {
+				AudioMute bool `json:"audioMute"`
+			} `json:"videoOut"`
 			AnalogOut struct {
 				AudioMute bool `json:"audioMute"`
+				AudioVol  int  `json:"audioVol"`
 			} `json:"analogOut"`
 		} `json:"zoneOut1"`
 
 		ZoneOut2 struct {
 			AudioSource string `json:"audioSource"`
 			AudioVol    int    `json:"audioVol"`
-
+			VideoOut    struct {
+				AudioMute bool `json:"audioMute"`
+			} `json: "videoOut"`
 			AnalogOut struct {
 				AudioMute bool `json:"audioMute"`
+				AudioVol  int  `json:"audioVol"`
 			} `json:"analogOut"`
 		} `json:"zoneOut2"`
 	} `json:"audOut"`

--- a/AT-OME-PS62/info.go
+++ b/AT-OME-PS62/info.go
@@ -69,6 +69,7 @@ func (vs *AtlonaVideoSwitcher6x2) Info(ctx context.Context) (interface{}, error)
 	return resp, nil
 }
 
+// Health Check End Point
 func (vs *AtlonaVideoSwitcher6x2) Healthy(ctx context.Context) error {
 	_, err := vs.AudioVideoInputs(ctx)
 	if err != nil {

--- a/AT-OME-PS62/volume.go
+++ b/AT-OME-PS62/volume.go
@@ -86,7 +86,7 @@ func (vs *AtlonaVideoSwitcher6x2) SetVolume(ctx context.Context, block string, l
 			level = int(convertedVolume)
 		}
 
-		// Set digital and analog audio together for the audio block
+		// Set analog audio for the audio block
 		body := fmt.Sprintf(`{ "setConfig": { "audio": { "audOut": { "%s": { "analogOut":{"audioVol": %d }}}}}}`, zblock, level)
 		if err := vs.setConfig(ctx, body); err != nil {
 			return fmt.Errorf("unable to set config: %w", err)
@@ -108,7 +108,7 @@ func (vs *AtlonaVideoSwitcher6x2) SetVolume(ctx context.Context, block string, l
 			level = int(convertedVolume)
 		}
 
-		// Set digital and analog audio together for the audio block
+		// Set digital audio for the audio block
 		body := fmt.Sprintf(`{ "setConfig": { "audio": { "audOut": { "%s": { "audioVol": %d }}}}}`, zblock, level)
 		if err := vs.setConfig(ctx, body); err != nil {
 			return fmt.Errorf("unable to set config: %w", err)
@@ -143,6 +143,7 @@ func (vs *AtlonaVideoSwitcher6x2) Mutes(ctx context.Context, blocks []string) (m
 //SetMute for all of the audio objects within the block
 func (vs *AtlonaVideoSwitcher6x2) SetMute(ctx context.Context, block string, muted bool) error {
 	zblock := ""
+	// Set Mutes for both analog and digital when configured with a combined block
 	if block == "zoneOut1" || block == "zoneOut2" {
 		body := fmt.Sprintf(`{ "setConfig": { "audio": { "audOut": { "%s": { "videoOut": { "audioMute": %t }, "analogOut": { "audioMute": %t }}}}}}`, block, muted, muted)
 		if err := vs.setConfig(ctx, body); err != nil {
@@ -150,6 +151,7 @@ func (vs *AtlonaVideoSwitcher6x2) SetMute(ctx context.Context, block string, mut
 		}
 
 		return nil
+		// Set mute for analog audio out for a given block
 	} else if block == "zoneOut1Analog" || block == "zoneOut2Analog" {
 		if block == "zoneOut1Analog" {
 			zblock = "zoneOut1"
@@ -163,7 +165,7 @@ func (vs *AtlonaVideoSwitcher6x2) SetMute(ctx context.Context, block string, mut
 		}
 
 		return nil
-
+		// Set mute for digital audio out for a given block
 	} else if block == "zoneOut1Digital" || block == "zoneOut2Digital" {
 		if block == "zoneOut1Digital" {
 			zblock = "zoneOut1"

--- a/AT-OME-PS62/volume.go
+++ b/AT-OME-PS62/volume.go
@@ -2,7 +2,6 @@ package atomeps62
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"math"
 )
@@ -28,10 +27,10 @@ func (vs *AtlonaVideoSwitcher6x2) Volumes(ctx context.Context, blocks []string) 
 	}
 
 	// Get the analog audio out on zoneOut1 volume
-	if config.Audio.AudOut.ZoneOut1.analogOut.audioVol < -50 {
+	if config.Audio.AudOut.ZoneOut1.AnalogOut.AudioVol < -50 {
 		vols["zoneOut1-Analog"] = 0
 	} else {
-		vols["zoneOut1-Analog"] = 2 * (config.Audio.AudOut.ZoneOut1.analogOut.audioVol + 50)
+		vols["zoneOut1-Analog"] = 2 * (config.Audio.AudOut.ZoneOut1.AnalogOut.AudioVol + 50)
 	}
 
 	// Get the digital audio out on zoneOut2 volume
@@ -42,10 +41,10 @@ func (vs *AtlonaVideoSwitcher6x2) Volumes(ctx context.Context, blocks []string) 
 	}
 
 	// Get the analog audio out on zoneOut2 volume
-	if config.Audio.AudOut.ZoneOut2.analogOut.audioVol < -50 {
+	if config.Audio.AudOut.ZoneOut2.AnalogOut.AudioVol < -50 {
 		vols["zoneOut1-Analog"] = 0
 	} else {
-		vols["zoneOut1-Analog"] = 2 * (config.Audio.AudOut.ZoneOut2.analogOut.audioVol + 50)
+		vols["zoneOut1-Analog"] = 2 * (config.Audio.AudOut.ZoneOut2.AnalogOut.AudioVol + 50)
 	}
 
 	return vols, nil
@@ -53,6 +52,7 @@ func (vs *AtlonaVideoSwitcher6x2) Volumes(ctx context.Context, blocks []string) 
 
 //SetVolume .
 func (vs *AtlonaVideoSwitcher6x2) SetVolume(ctx context.Context, block string, level int) error {
+	zblock := ""
 	if block == "zoneOut1" || block == "zoneOut2" {
 
 		// Atlona volume levels are from -90 to 10 and the number we receive is 0-100
@@ -73,9 +73,9 @@ func (vs *AtlonaVideoSwitcher6x2) SetVolume(ctx context.Context, block string, l
 		return nil
 	} else if block == "zoneOut1Analog" || block == "zoneOut2Analog" {
 		if block == "zoneOut1Analog" {
-			zblock := "zoneOut1"
+			zblock = "zoneOut1"
 		} else {
-			zblock := "zoneOut2"
+			zblock = "zoneOut2"
 		}
 		// Atlona volume levels are from -90 to 10 and the number we receive is 0-100
 		// If volume level is supposed to be zero set it -90 on atlona
@@ -87,7 +87,7 @@ func (vs *AtlonaVideoSwitcher6x2) SetVolume(ctx context.Context, block string, l
 		}
 
 		// Set digital and analog audio together for the audio block
-		body := fmt.Sprintf(`{ "setConfig": { "audio": { "audOut": { "%s": { "analogOut":{"audioVol": %d }}}}}}`, zblock, level, level)
+		body := fmt.Sprintf(`{ "setConfig": { "audio": { "audOut": { "%s": { "analogOut":{"audioVol": %d }}}}}}`, zblock, level)
 		if err := vs.setConfig(ctx, body); err != nil {
 			return fmt.Errorf("unable to set config: %w", err)
 		}
@@ -95,9 +95,9 @@ func (vs *AtlonaVideoSwitcher6x2) SetVolume(ctx context.Context, block string, l
 		return nil
 	} else if block == "zoneOut1Digital" || block == "zoneOut2Digital" {
 		if block == "zoneOut1Digital" {
-			zblock := "zoneOut1"
+			zblock = "zoneOut1"
 		} else {
-			zblock := "zoneOut2"
+			zblock = "zoneOut2"
 		}
 		// Atlona volume levels are from -90 to 10 and the number we receive is 0-100
 		// If volume level is supposed to be zero set it -90 on atlona
@@ -109,7 +109,7 @@ func (vs *AtlonaVideoSwitcher6x2) SetVolume(ctx context.Context, block string, l
 		}
 
 		// Set digital and analog audio together for the audio block
-		body := fmt.Sprintf(`{ "setConfig": { "audio": { "audOut": { "%s": { "audioVol": %d }}}}}`, zblock, level, level)
+		body := fmt.Sprintf(`{ "setConfig": { "audio": { "audOut": { "%s": { "audioVol": %d }}}}}`, zblock, level)
 		if err := vs.setConfig(ctx, body); err != nil {
 			return fmt.Errorf("unable to set config: %w", err)
 		}
@@ -142,6 +142,7 @@ func (vs *AtlonaVideoSwitcher6x2) Mutes(ctx context.Context, blocks []string) (m
 
 //SetMute for all of the audio objects within the block
 func (vs *AtlonaVideoSwitcher6x2) SetMute(ctx context.Context, block string, muted bool) error {
+	zblock := ""
 	if block == "zoneOut1" || block == "zoneOut2" {
 		body := fmt.Sprintf(`{ "setConfig": { "audio": { "audOut": { "%s": { "videoOut": { "audioMute": %t }, "analogOut": { "audioMute": %t }}}}}}`, block, muted, muted)
 		if err := vs.setConfig(ctx, body); err != nil {
@@ -151,10 +152,11 @@ func (vs *AtlonaVideoSwitcher6x2) SetMute(ctx context.Context, block string, mut
 		return nil
 	} else if block == "zoneOut1Analog" || block == "zoneOut2Analog" {
 		if block == "zoneOut1Analog" {
-			zblock := "zoneOut1"
+			zblock = "zoneOut1"
 		} else {
-			zblock := "zoneOut2"
+			zblock = "zoneOut2"
 		}
+
 		body := fmt.Sprintf(`{ "setConfig": { "audio": { "audOut": { "%s": { "analogOut": { "audioMute": %t }}}}}}`, zblock, muted)
 		if err := vs.setConfig(ctx, body); err != nil {
 			return fmt.Errorf("unable to set config: %w", err)
@@ -164,11 +166,12 @@ func (vs *AtlonaVideoSwitcher6x2) SetMute(ctx context.Context, block string, mut
 
 	} else if block == "zoneOut1Digital" || block == "zoneOut2Digital" {
 		if block == "zoneOut1Digital" {
-			zblock := "zoneOut1"
+			zblock = "zoneOut1"
 		} else {
-			zblock := "zoneOut2"
+			zblock = "zoneOut2"
 		}
-		body := fmt.Sprintf(`{ "setConfig": { "audio": { "audOut": { "%s": { "videoOut": { "audioMute": %t }, "analogOut": { "audioMute": %t }}}}}}`, zblock, muted)
+
+		body := fmt.Sprintf(`{ "setConfig": { "audio": { "audOut": { "%s": { "videoOut": { "audioMute": %t }}}}}}`, zblock, muted)
 		if err := vs.setConfig(ctx, body); err != nil {
 			return fmt.Errorf("unable to set config: %w", err)
 		}

--- a/AT-OME-PS62/volume.go
+++ b/AT-OME-PS62/volume.go
@@ -20,18 +20,32 @@ func (vs *AtlonaVideoSwitcher6x2) Volumes(ctx context.Context, blocks []string) 
 	// (since we don't have to do any extra work)
 	vols := make(map[string]int)
 
-	// zoneOut1 volume
+	// Get the digital audio out on zoneOut1 volume
 	if config.Audio.AudOut.ZoneOut1.AudioVol < -50 {
-		vols["zoneOut1"] = 0
+		vols["zoneOut1-Digital"] = 0
 	} else {
-		vols["zoneOut1"] = 2 * (config.Audio.AudOut.ZoneOut1.AudioVol + 50)
+		vols["zoneOut1-Digital"] = 2 * (config.Audio.AudOut.ZoneOut1.AudioVol + 50)
 	}
 
-	// zoneOut2 volume
-	if config.Audio.AudOut.ZoneOut2.AudioVol < -50 {
-		vols["zoneOut2"] = 0
+	// Get the analog audio out on zoneOut1 volume
+	if config.Audio.AudOut.ZoneOut1.analogOut.audioVol < -50 {
+		vols["zoneOut1-Analog"] = 0
 	} else {
-		vols["zoneOut2"] = 2 * (config.Audio.AudOut.ZoneOut2.AudioVol + 50)
+		vols["zoneOut1-Analog"] = 2 * (config.Audio.AudOut.ZoneOut1.analogOut.audioVol + 50)
+	}
+
+	// Get the digital audio out on zoneOut2 volume
+	if config.Audio.AudOut.ZoneOut2.AudioVol < -50 {
+		vols["zoneOut2-Digital"] = 0
+	} else {
+		vols["zoneOut2-Digital"] = 2 * (config.Audio.AudOut.ZoneOut2.AudioVol + 50)
+	}
+
+	// Get the analog audio out on zoneOut2 volume
+	if config.Audio.AudOut.ZoneOut2.analogOut.audioVol < -50 {
+		vols["zoneOut1-Analog"] = 0
+	} else {
+		vols["zoneOut1-Analog"] = 2 * (config.Audio.AudOut.ZoneOut2.analogOut.audioVol + 50)
 	}
 
 	return vols, nil
@@ -39,25 +53,71 @@ func (vs *AtlonaVideoSwitcher6x2) Volumes(ctx context.Context, blocks []string) 
 
 //SetVolume .
 func (vs *AtlonaVideoSwitcher6x2) SetVolume(ctx context.Context, block string, level int) error {
-	if block != "zoneOut1" && block != "zoneOut2" {
-		return errors.New("invalid block")
-	}
+	if block == "zoneOut1" || block == "zoneOut2" {
 
-	// Atlona volume levels are from -90 to 10 and the number we receive is 0-100
-	// If volume level is supposed to be zero set it -90 on atlona
-	if level == 0 {
-		level = -90
+		// Atlona volume levels are from -90 to 10 and the number we receive is 0-100
+		// If volume level is supposed to be zero set it -90 on atlona
+		if level == 0 {
+			level = -90
+		} else {
+			convertedVolume := -50 + math.Round(float64(level/2))
+			level = int(convertedVolume)
+		}
+
+		// Set digital and analog audio together for the audio block
+		body := fmt.Sprintf(`{ "setConfig": { "audio": { "audOut": { "%s": { "audioVol": %d, "analogOut":{"audioVol": %d }}}}}}`, block, level, level)
+		if err := vs.setConfig(ctx, body); err != nil {
+			return fmt.Errorf("unable to set config: %w", err)
+		}
+
+		return nil
+	} else if block == "zoneOut1Analog" || block == "zoneOut2Analog" {
+		if block == "zoneOut1Analog" {
+			zblock := "zoneOut1"
+		} else {
+			zblock := "zoneOut2"
+		}
+		// Atlona volume levels are from -90 to 10 and the number we receive is 0-100
+		// If volume level is supposed to be zero set it -90 on atlona
+		if level == 0 {
+			level = -90
+		} else {
+			convertedVolume := -50 + math.Round(float64(level/2))
+			level = int(convertedVolume)
+		}
+
+		// Set digital and analog audio together for the audio block
+		body := fmt.Sprintf(`{ "setConfig": { "audio": { "audOut": { "%s": { "analogOut":{"audioVol": %d }}}}}}`, zblock, level, level)
+		if err := vs.setConfig(ctx, body); err != nil {
+			return fmt.Errorf("unable to set config: %w", err)
+		}
+
+		return nil
+	} else if block == "zoneOut1Digital" || block == "zoneOut2Digital" {
+		if block == "zoneOut1Digital" {
+			zblock := "zoneOut1"
+		} else {
+			zblock := "zoneOut2"
+		}
+		// Atlona volume levels are from -90 to 10 and the number we receive is 0-100
+		// If volume level is supposed to be zero set it -90 on atlona
+		if level == 0 {
+			level = -90
+		} else {
+			convertedVolume := -50 + math.Round(float64(level/2))
+			level = int(convertedVolume)
+		}
+
+		// Set digital and analog audio together for the audio block
+		body := fmt.Sprintf(`{ "setConfig": { "audio": { "audOut": { "%s": { "audioVol": %d }}}}}`, zblock, level, level)
+		if err := vs.setConfig(ctx, body); err != nil {
+			return fmt.Errorf("unable to set config: %w", err)
+		}
+
+		return nil
 	} else {
-		convertedVolume := -50 + math.Round(float64(level/2))
-		level = int(convertedVolume)
+		return fmt.Errorf("Unable to set config: Block %v is not a valid block", block)
 	}
-
-	body := fmt.Sprintf(`{ "setConfig": { "audio": { "audOut": { "%s": { "audioVol": %d }}}}}`, block, level)
-	if err := vs.setConfig(ctx, body); err != nil {
-		return fmt.Errorf("unable to set config: %w", err)
-	}
-
-	return nil
 }
 
 //Mutes .
@@ -72,22 +132,51 @@ func (vs *AtlonaVideoSwitcher6x2) Mutes(ctx context.Context, blocks []string) (m
 	// always return all of the blocks, regardless of `blocks`
 	// (since we don't have to do any extra work)
 	mutes := make(map[string]bool)
-	mutes["zoneOut1"] = config.Audio.AudOut.ZoneOut1.AnalogOut.AudioMute
-	mutes["zoneOut2"] = config.Audio.AudOut.ZoneOut2.AnalogOut.AudioMute
+	mutes["zoneOut1-Analog"] = config.Audio.AudOut.ZoneOut1.AnalogOut.AudioMute
+	mutes["zoneOut1-Digital"] = config.Audio.AudOut.ZoneOut1.VideoOut.AudioMute
+	mutes["zoneOut2-Analog"] = config.Audio.AudOut.ZoneOut2.AnalogOut.AudioMute
+	mutes["zoneOut2-Digital"] = config.Audio.AudOut.ZoneOut2.VideoOut.AudioMute
 
 	return mutes, nil
 }
 
-//SetMute .
+//SetMute for all of the audio objects within the block
 func (vs *AtlonaVideoSwitcher6x2) SetMute(ctx context.Context, block string, muted bool) error {
-	if block != "zoneOut1" && block != "zoneOut2" {
-		return errors.New("invalid block")
+	if block == "zoneOut1" || block == "zoneOut2" {
+		body := fmt.Sprintf(`{ "setConfig": { "audio": { "audOut": { "%s": { "videoOut": { "audioMute": %t }, "analogOut": { "audioMute": %t }}}}}}`, block, muted, muted)
+		if err := vs.setConfig(ctx, body); err != nil {
+			return fmt.Errorf("unable to set config: %w", err)
+		}
+
+		return nil
+	} else if block == "zoneOut1Analog" || block == "zoneOut2Analog" {
+		if block == "zoneOut1Analog" {
+			zblock := "zoneOut1"
+		} else {
+			zblock := "zoneOut2"
+		}
+		body := fmt.Sprintf(`{ "setConfig": { "audio": { "audOut": { "%s": { "analogOut": { "audioMute": %t }}}}}}`, zblock, muted)
+		if err := vs.setConfig(ctx, body); err != nil {
+			return fmt.Errorf("unable to set config: %w", err)
+		}
+
+		return nil
+
+	} else if block == "zoneOut1Digital" || block == "zoneOut2Digital" {
+		if block == "zoneOut1Digital" {
+			zblock := "zoneOut1"
+		} else {
+			zblock := "zoneOut2"
+		}
+		body := fmt.Sprintf(`{ "setConfig": { "audio": { "audOut": { "%s": { "videoOut": { "audioMute": %t }, "analogOut": { "audioMute": %t }}}}}}`, zblock, muted)
+		if err := vs.setConfig(ctx, body); err != nil {
+			return fmt.Errorf("unable to set config: %w", err)
+		}
+
+		return nil
+
+	} else {
+		return fmt.Errorf("Unable to set config: Block %v is not a valid block", block)
 	}
 
-	body := fmt.Sprintf(`{ "setConfig": { "audio": { "audOut": { "%s": { "analogOut": { "audioMute": %t }}}}}}`, block, muted)
-	if err := vs.setConfig(ctx, body); err != nil {
-		return fmt.Errorf("unable to set config: %w", err)
-	}
-
-	return nil
 }


### PR DESCRIPTION
fixed audio settings on the 6x2 code to fit with the new 1.2 firmware where they split out the audio controls into 4 different controls.  